### PR TITLE
Make the store compatible with React 17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 		"@testing-library/react": "^16.3.0",
 		"@types/react": "^19.2.2",
 		"@types/react-dom": "^19.2.2",
+		"@types/use-sync-external-store": "^1.5.0",
 		"@vitest/ui": "^4.0.6",
 		"happy-dom": "^20.0.10",
 		"react": "^19.2.0",
@@ -52,10 +53,11 @@
 		"vitest": "^4.0.6"
 	},
 	"dependencies": {
-		"signal-polyfill": "^0.2.2"
+		"signal-polyfill": "^0.2.2",
+		"use-sync-external-store": "^1.6.0"
 	},
 	"peerDependencies": {
-		"react": "^18.0.0 || ^19.0.0"
+		"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
 	},
 	"peerDependenciesMeta": {
 		"react": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       signal-polyfill:
         specifier: ^0.2.2
         version: 0.2.2
+      use-sync-external-store:
+        specifier: ^1.6.0
+        version: 1.6.0(react@19.2.0)
     devDependencies:
       '@biomejs/biome':
         specifier: 2.3.3
@@ -27,6 +30,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.2
         version: 19.2.2(@types/react@19.2.2)
+      '@types/use-sync-external-store':
+        specifier: ^1.5.0
+        version: 1.5.0
       '@vitest/ui':
         specifier: ^4.0.6
         version: 4.0.6(vitest@4.0.6)
@@ -437,6 +443,9 @@ packages:
   '@types/react@19.2.2':
     resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
 
+  '@types/use-sync-external-store@1.5.0':
+    resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -678,6 +687,11 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite@7.1.12:
     resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
@@ -1014,6 +1028,8 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/use-sync-external-store@1.5.0': {}
+
   '@types/whatwg-mimetype@3.0.2': {}
 
   '@vitest/expect@4.0.6':
@@ -1262,6 +1278,10 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  use-sync-external-store@1.6.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
 
   vite@7.1.12(@types/node@20.19.24):
     dependencies:

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 import type { StateObject, StatePrimitive, Store } from "./index.js";
 
 /**


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
<!-- Link to any related issues using #issue-number. This is **required** for feature requests! -->

This PR adds React 17 compatibility by using the `use-sync-external-store` shim instead of relying on React's built-in `useSyncExternalStore` hook (which is only available in React 18+).

The changes include:
- Added `use-sync-external-store` as a dependency
- Added `@types/use-sync-external-store` as a dev dependency
- Updated `src/react.ts` to import from `use-sync-external-store/shim` instead of `react`
- Extended `peerDependencies` to include React 17 (`^17.0.0 || ^18.0.0 || ^19.0.0`)

This ensures the library works seamlessly across React 17, 18, and 19 without breaking changes.

## Type of Change
<!-- Mark the relevant option with an "x" -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update

## Testing
<!-- Describe the tests you ran to verify your changes -->

- [x] Existing tests pass
- [ ] Added new tests for changes
- [x] Tested manually (describe below)

**Manual Testing Details:**
- Verified that existing tests continue to pass with the new dependency
- Confirmed that the shim correctly provides the `useSyncExternalStore` API (our app is still stuck with React 17)
- Verified type definitions are correctly resolved with `@types/use-sync-external-store`

## Checklist

- [ ] I discussed this change in a GitHub issue before submitting this PR
- [x] I have run the linter, formatter, and tests to ensure my code is ready for review